### PR TITLE
Remove reference to old version after major upgrade

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -148,7 +148,6 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/jfrog/terraform-provider-artifactory/v9 v9.9.2 // indirect
 	github.com/jfrog/terraform-provider-shared v1.21.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1766,8 +1766,6 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jfrog/terraform-provider-artifactory/v10 v10.0.0 h1:myVNGdfIboCOX+1+4C+/sMshE/MQ/PDlRScbzUmwut8=
 github.com/jfrog/terraform-provider-artifactory/v10 v10.0.0/go.mod h1:3oQWE09DS0tiRQvBO03zrHnpWANAlXy/ssds4gXZ+VM=
-github.com/jfrog/terraform-provider-artifactory/v9 v9.9.2 h1:gLcDY4XDun02KG8Aua3X2j3aRfXl8YeS69ELhaFJfeQ=
-github.com/jfrog/terraform-provider-artifactory/v9 v9.9.2/go.mod h1:PvGcOnrgyLiMg+uvnO5doIM6WZm2PvMYB6dUTU87UT0=
 github.com/jfrog/terraform-provider-shared v1.21.1 h1:hBlk7087fjMVk7fdx2BkpZM3RnLIzS6fGNZEJc5HLYc=
 github.com/jfrog/terraform-provider-shared v1.21.1/go.mod h1:Ioq1OBLb2h9uj4t4KzBEfA1piHbUg+Lgvn84Vbzk5uI=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
@@ -2189,8 +2187,6 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5 h1:1DJMji9F7XPea46bSuhy4/85n8J4/Mfz8PWLZtjKKiI=
 github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5/go.mod h1:Y6W21yUukvxS2NnS5ae1beMSPhMvj0xNAYcDqDHVj/g=
-github.com/pulumi/pulumi-artifactory/provider/v5 v5.0.0-20231214205801-987aace2728e h1:jF+4gWoNchSG8yFeR+9p6j/m/sKz3p/Po5+hjE713k4=
-github.com/pulumi/pulumi-artifactory/provider/v5 v5.0.0-20231214205801-987aace2728e/go.mod h1:2xhws009C3mt+IR+h3IKD1ityDgCi8FAkdyrOUDeFls=
 github.com/pulumi/pulumi-java/pkg v0.9.8 h1:c8mYsalnRXA2Ibgvv6scefOn6mW1Vb0UT0mcDqjsivQ=
 github.com/pulumi/pulumi-java/pkg v0.9.8/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
 github.com/pulumi/pulumi-terraform-bridge/pf v0.21.0 h1:rKL6YQh55C6BTElSzox6VyuDDhxu8zh59qlECe4wkIM=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -4,7 +4,6 @@ go 1.21
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/pulumi/pulumi-artifactory/sdk/v5 v5.5.2
 	github.com/pulumi/pulumi/sdk/v3 v3.96.2
 )
 
@@ -68,6 +67,7 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -151,8 +151,6 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.5.6 h1:4WV3X7OEVcChIwbSG+JxhZDdmq/q7lFPaSjHRYlPwmI=
 github.com/pulumi/esc v0.5.6/go.mod h1:wpwNfVS5fV7Kd51j4dJ6FWYlKfxdqyppgp0gtkzqH04=
-github.com/pulumi/pulumi-artifactory/sdk/v5 v5.5.2 h1:aNnrW6NETzyvNiFXu1ikIpqJ51dk96s6flZac1inGfM=
-github.com/pulumi/pulumi-artifactory/sdk/v5 v5.5.2/go.mod h1:v1nZmaDYZEOzAytTDBtRsy2IVuKawfzqQidHpj42VsQ=
 github.com/pulumi/pulumi/sdk/v3 v3.96.2 h1:q5ZKdf+e9JR+a6Eiueg0Ohy6jCQGk9pO2V7xI/qGP3I=
 github.com/pulumi/pulumi/sdk/v3 v3.96.2/go.mod h1:yvD23IIRiqIXuo4kaZNe5zK/uT0nhO99wr6BVEqoi7A=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Automatic upgrades are currently erroring by claiming that this is a major upgrade, which is wrong. It should be a patch upgrade. I'm hoping this will fix it.